### PR TITLE
Fix venv permissions

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -39,7 +39,8 @@ RUN mkdir -p /usr/src/venvs \
     && python -m venv /usr/src/venvs/app-main
 COPY requirements.txt /usr/src/
 RUN /usr/src/venvs/app-main/bin/pip install --upgrade pip \
-    && /usr/src/venvs/app-main/bin/pip install -r /usr/src/requirements.txt
+    && /usr/src/venvs/app-main/bin/pip install -r /usr/src/requirements.txt \
+    && chown -R appuser:appuser /usr/src/venvs/app-main
 
 # Switch to the non-root user
 USER appuser


### PR DESCRIPTION
## Summary
- update devcontainer Dockerfile to ensure appuser owns the Python virtualenv

## Testing
- `python app-main/helloworld.py`
- `python -m py_compile app-main/helloworld.py`


------
https://chatgpt.com/codex/tasks/task_e_6842d7aa35e0832c862d9f72ed5026b0