### PR TITLE
Fix fuzzy search index result

### DIFF
--- a/app-main/prototype.py
+++ b/app-main/prototype.py
@@ -108,7 +108,7 @@ def locate_snippet(snippet: str, book_text: str) -> int:
         for i in range(len(book_words) - win_len)
     ]
 
-    idx, score, _ = process.extractOne(
+    _match, score, idx = process.extractOne(
         target,
         candidates,
         scorer=Levenshtein.normalized_similarity,


### PR DESCRIPTION
## Summary
- fix variable assignment in `locate_snippet` so the index is returned properly

## Testing
- `python app-main/prototype.py` *(fails to locate epub but runs)*

------
https://chatgpt.com/codex/tasks/task_e_6842f21656b4832c9a3e855634cf080f