### PR TITLE
Expand QA retrieval

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,5 +3,6 @@
 Appen hjælper dig med at få overblik over personer i en roman ved hjælp af kunstig intelligens.
 
 This repository now includes `prototype.py` which demonstrates a simple chat interface for exploring characters in a book.
+The Q\&A loop can answer basic questions about the text found up to a detected location.
 
 If `app-main/Kongetro.epub.zip` is present, the prototype can also detect the page number by searching the provided text snippet in the book. Otherwise it falls back to placeholder pages.


### PR DESCRIPTION
## Summary
- implement retrieval-based `answer_question`
- document the Q&A capability

## Testing
- `python -m py_compile app-main/prototype.py`
- `python app-main/prototype.py` *(fails: Kongetro.epub.zip not found)*

------
https://chatgpt.com/codex/tasks/task_e_6842ff68e784832c8ccd6d11cad8a018