### PR TITLE
Add GPT-4 context Q&A

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,3 +6,13 @@ This repository now includes `prototype.py` which demonstrates a simple chat int
 The Q\&A loop can answer basic questions about the text found up to a detected location.
 
 If `app-main/Kongetro.epub.zip` is present, the prototype can also detect the page number by searching the provided text snippet in the book. Otherwise it falls back to placeholder pages.
+
+## Setup
+
+Create a `.env` file in the project root containing your OpenAI API key:
+
+```
+OPENAI_API_KEY=<your_key>
+```
+
+The `prototype.py` script uses this key to query GPT-4 for answers about the book based on the text up to a detected snippet.


### PR DESCRIPTION
## Summary
- integrate OpenAI with env vars loaded via `python-dotenv`
- upgrade `answer_question` to query GPT-4 with the page context
- build context from book text up to the found snippet
- document API setup in README

## Testing
- `python -m py_compile app-main/prototype.py`

------
https://chatgpt.com/codex/tasks/task_e_6843060d46ac832c9c2225e075b5b5eb