### PR TITLE
Fix prototype for OpenAI v1 API

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,3 +16,10 @@ OPENAI_API_KEY=<your_key>
 ```
 
 The `prototype.py` script uses this key to query GPT-4 for answers about the book based on the text up to a detected snippet.
+
+This project expects the `openai` Python package version 1.0 or newer. If you
+have an older installation, upgrade with:
+
+```
+pip install -U openai
+```

--- a/app-main/prototype.py
+++ b/app-main/prototype.py
@@ -20,11 +20,13 @@ import openai  # OpenAI API client
 from dotenv import load_dotenv
 
 load_dotenv()  # Load environment variables from a .env file
-openai.api_key = os.getenv("OPENAI_API_KEY")
-if not openai.api_key:
+api_key = os.getenv("OPENAI_API_KEY")
+if not api_key:
     raise RuntimeError(
         "OpenAI API key not found. Set OPENAI_API_KEY in your .env file."
     )
+
+client = openai.OpenAI(api_key=api_key)
 
 from rapidfuzz import process
 from rapidfuzz.distance import Levenshtein
@@ -165,7 +167,7 @@ def answer_question(question: str, context: str) -> str:
     )
 
     try:
-        response = openai.ChatCompletion.create(
+        response = client.chat.completions.create(
             model="gpt-4",
             messages=[
                 {"role": "system", "content": system_message},


### PR DESCRIPTION
## Summary
- switch prototype to new `openai.OpenAI` client
- update README with upgrade instructions

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_6843095ea90c832ca5513184659e6785