### PR TITLE
Add .env example for devcontainer

### DIFF
--- a/.devcontainer/.env.example
+++ b/.devcontainer/.env.example
@@ -1,0 +1,1 @@
+OPENAI_API_KEY=sk

--- a/README.md
+++ b/README.md
@@ -19,6 +19,10 @@ Create a `.env` file in the project root containing your OpenAI API key:
 OPENAI_API_KEY=<your_key>
 ```
 
+You can also copy `.devcontainer/.env.example` to `.env` as a starting point. The
+example file contains a placeholder key `OPENAI_API_KEY=sk` that you should
+replace with your own.
+
 The `prototype.py` script uses this key to query GPT-4 for answers about the book based on the text up to a detected snippet.
 
 This project expects the `openai` Python package version 1.0 or newer. If you


### PR DESCRIPTION
## Summary
- add `.devcontainer/.env.example` containing a placeholder OpenAI API key
- mention the example env file in setup instructions

## Testing
- `python -m pip check`


------
https://chatgpt.com/codex/tasks/task_e_6843167d6524832c828a623bd0f4cccd